### PR TITLE
Add sdcard

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm7150-xiaomi-sweet.dts
+++ b/arch/arm64/boot/dts/qcom/sm7150-xiaomi-sweet.dts
@@ -359,6 +359,17 @@
 	};
 };
 
+&sdhc_2 {
+	status = "okay";
+
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&sdc2_on>;
+	pinctrl-1 = <&sdc2_off>;
+	vmmc-supply = <&vreg_l9c_3p1>;
+	vqmmc-supply = <&vreg_l6c_3p0>;
+
+	cd-gpios = <&tlmm 69 GPIO_ACTIVE_HIGH>;
+};
 &usb_1 {
 	status = "okay";
 
@@ -381,4 +392,56 @@
 
 &tlmm {
 	gpio-reserved-ranges = <0 4>, <59 4>;
+
+	sdc2_on: sdc2-on {
+		pinconf-clk {
+			pins = "sdc2_clk";
+			bias-disable;
+			drive-strength = <16>;
+		};
+
+		pinconf-cmd {
+			pins = "sdc2_cmd";
+			bias-pull-up;
+			drive-strength = <10>;
+		};
+
+		pinconf-data {
+			pins = "sdc2_data";
+			bias-pull-up;
+			drive-strength = <10>;
+		};
+
+		pinconf-sd-cd {
+			pins = "gpio69";
+			bias-pull-up;
+			drive-strength = <2>;
+		};
+	};
+
+	sdc2_off: sdc2-off {
+		pinconf-clk {
+			pins = "sdc2_clk";
+			bias-disable;
+			drive-strength = <2>;
+		};
+
+		pinconf-cmd {
+			pins = "sdc2_cmd";
+			bias-pull-up;
+			drive-strength = <2>;
+		};
+
+		pinconf-data {
+			pins = "sdc2_data";
+			bias-pull-up;
+			drive-strength = <2>;
+		};
+
+		pinconf-sd-cd {
+			pins = "gpio69";
+			bias-disable;
+			drive-strength = <2>;
+		};
+	};
 };


### PR DESCRIPTION
Enable sdcard on sweet. Note that there is a difference with surya that came out looking at the kernel shipped with PixelExperience:

```
pins = "gpio69";
bias-disable;
```
istead of 
```
pins = "gpio69";
bias-pull-up;
```

