### PR TITLE
xiaomi-sweet: remoteprocs

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm7150-xiaomi-sweet.dts
+++ b/arch/arm64/boot/dts/qcom/sm7150-xiaomi-sweet.dts
@@ -396,7 +396,21 @@
 		bias-pull-up;
 		power-source = <0>;
 	};
+};
 
+&remoteproc_adsp {
+	status = "okay";
+	firmware-name = "qcom/sm7150/sweet/adsp.mbn";
+};
+
+&remoteproc_cdsp {
+	status = "okay";
+	firmware-name = "qcom/sm7150/sweet/cdsp.mbn";
+};
+
+&remoteproc_mpss {
+	status = "okay";
+	firmware-name = "qcom/sm7150/sweet/modem.mbn";
 };
 
 &sdhc_2 {


### PR DESCRIPTION
Currently mpss is non-functional: here is the relevant part of dmesg with `CONFIG_DYNAMIC_DEBUG` and  `dyndbg="file drivers/base/firmware_loader/main.c +fmp"`

```
[   19.691870] remoteproc remoteproc0: 4080000.remoteproc is available
[   19.693577] remoteproc remoteproc1: 62400000.remoteproc is available
[   19.693644] firmware_class:__allocate_fw_priv: firmware_class: __allocate_fw_priv: fw-qcom/sm7150/sweet/adsp.mbn fw_priv=00000000a55fc05c
[   19.695169] remoteproc remoteproc2: 8300000.remoteproc is available
[   19.695234] firmware_class:__allocate_fw_priv: firmware_class: __allocate_fw_priv: fw-qcom/sm7150/sweet/cdsp.mbn fw_priv=000000006062125d
[   19.695928] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc1: loading /lib/firmware/postmarketos/qcom/sm7150/sweet/adsp.mbn failed for no such file or directory.
[   19.695931] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc2: loading /lib/firmware/postmarketos/qcom/sm7150/sweet/cdsp.mbn failed for no such file or directory.
[   19.695967] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc2: loading /lib/firmware/updates/6.0.0-sm7150/qcom/sm7150/sweet/cdsp.mbn failed for no such file or directory.
[   19.695978] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc1: loading /lib/firmware/updates/6.0.0-sm7150/qcom/sm7150/sweet/adsp.mbn failed for no such file or directory.
[   19.695979] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc2: loading /lib/firmware/updates/qcom/sm7150/sweet/cdsp.mbn failed for no such file or directory.
[   19.695991] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc1: loading /lib/firmware/updates/qcom/sm7150/sweet/adsp.mbn failed for no such file or directory.
[   19.695993] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc2: loading /lib/firmware/6.0.0-sm7150/qcom/sm7150/sweet/cdsp.mbn failed for no such file or directory.
[   19.696002] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc1: loading /lib/firmware/6.0.0-sm7150/qcom/sm7150/sweet/adsp.mbn failed for no such file or directory.
[   20.781948] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc2: Loading firmware from /lib/firmware/qcom/sm7150/sweet/cdsp.mbn
[   20.781968] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc2: direct-loading qcom/sm7150/sweet/cdsp.mbn
[   20.781983] firmware_class:fw_set_page_data: firmware_class: fw_set_page_data: fw-qcom/sm7150/sweet/cdsp.mbn fw_priv=000000006062125d data=00000000e1660988 size=2922004
[   20.781996] remoteproc remoteproc2: powering up 8300000.remoteproc
[   20.782004] firmware_class:alloc_lookup_fw_priv: firmware_class: batched request - sharing the same struct fw_priv and lookup for multiple requests
[   20.782009] firmware_class:fw_set_page_data: firmware_class: fw_set_page_data: fw-qcom/sm7150/sweet/cdsp.mbn fw_priv=000000006062125d data=00000000e1660988 size=2922004
[   20.782017] remoteproc remoteproc2: Booting fw image qcom/sm7150/sweet/cdsp.mbn, size 2922004
[   20.956545] remoteproc remoteproc2: remote processor 8300000.remoteproc is now up
[   20.956569] firmware_class:__free_fw_priv: firmware_class: __free_fw_priv: fw-qcom/sm7150/sweet/cdsp.mbn fw_priv=000000006062125d data=00000000e1660988 size=2922004
[   23.754319] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc1: Loading firmware from /lib/firmware/qcom/sm7150/sweet/adsp.mbn
[   23.754341] firmware_class:fw_get_filesystem_firmware: remoteproc remoteproc1: direct-loading qcom/sm7150/sweet/adsp.mbn
[   23.754358] firmware_class:fw_set_page_data: firmware_class: fw_set_page_data: fw-qcom/sm7150/sweet/adsp.mbn fw_priv=00000000a55fc05c data=000000001c200ce0 size=19669188
[   23.754374] remoteproc remoteproc1: powering up 62400000.remoteproc
[   23.754382] firmware_class:alloc_lookup_fw_priv: firmware_class: batched request - sharing the same struct fw_priv and lookup for multiple requests
[   23.754388] firmware_class:fw_set_page_data: firmware_class: fw_set_page_data: fw-qcom/sm7150/sweet/adsp.mbn fw_priv=00000000a55fc05c data=000000001c200ce0 size=19669188
[   23.754396] remoteproc remoteproc1: Booting fw image qcom/sm7150/sweet/adsp.mbn, size 19669188
[   23.832440] qcom,fastrpc-cb 8300000.remoteproc:glink-edge:fastrpc:compute-cb@1: Adding to iommu group 3
[   23.833486] qcom,fastrpc-cb 8300000.remoteproc:glink-edge:fastrpc:compute-cb@2: Adding to iommu group 4
[   23.834302] qcom,fastrpc-cb 8300000.remoteproc:glink-edge:fastrpc:compute-cb@3: Adding to iommu group 5
[   23.837715] qcom,fastrpc-cb 8300000.remoteproc:glink-edge:fastrpc:compute-cb@4: Adding to iommu group 6
[   23.838699] qcom,fastrpc-cb 8300000.remoteproc:glink-edge:fastrpc:compute-cb@5: Adding to iommu group 7
[   23.839549] qcom,fastrpc-cb 8300000.remoteproc:glink-edge:fastrpc:compute-cb@6: Adding to iommu group 8
[   23.840317] qcom,fastrpc-cb 8300000.remoteproc:glink-edge:fastrpc:compute-cb@7: Adding to iommu group 9
[   23.841413] qcom,fastrpc-cb 8300000.remoteproc:glink-edge:fastrpc:compute-cb@8: Adding to iommu group 10
[   23.908631] remoteproc remoteproc1: remote processor 62400000.remoteproc is now up
[   23.908662] firmware_class:__free_fw_priv: firmware_class: __free_fw_priv: fw-qcom/sm7150/sweet/adsp.mbn fw_priv=00000000a55fc05c data=000000001c200ce0 size=19669188
```