### PR TITLE
arm64: dts: qcom: sm7150-xiaomi-davinci: enable IPA

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dts
+++ b/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dts
@@ -121,7 +121,7 @@
 
 		rmtfs_mem: memory@fde01000 {
 			compatible = "qcom,rmtfs-mem";
-			reg = <0 0xfde01000 0 0x200000>;
+			reg = <0 0xf2e01000 0 0x200000>;
 			no-map;
 
 			qcom,client-id = <1>;
@@ -441,6 +441,13 @@
 	clock-frequency = <100000>;
 
 	/* goodix,gt9889 (touchscreen) @ 5d */
+};
+
+&ipa {
+	status = "okay";
+
+	memory-region = <&ipa_fw_mem>;
+	firmware-name = "qcom/sm7150/davinci/ipa_fws.mbn";
 };
 
 &pm6150_pon {


### PR DESCRIPTION
I couldn't fully get the SIM to work in modemmanager yet, but it shows up and can be unlocked.

What I'm currently doing:
```
davinci:~$ sudo qmicli -d qrtr://0 --uim-change-provisioning-session="slot=1,activate=yes,session-type=primary-gw-provisioning,aid=MY_AID"
davinci:~$ qmicli -d qrtr://0 --uim-verify-pin=PIN1,MY_PIN
davinci:~$ qmicli -d qrtr://0 --uim-get-card-status
[qrtr://0] Successfully got card status
Provisioning applications:
  Primary GW:   slot '1', application '1'
  Primary 1X:   session doesn't exist
  Secondary GW: session doesn't exist
  Secondary 1X: session doesn't exist
Slot [1]:
  Card state: 'present'
  UPIN state: 'not-initialized'
    UPIN retries: '0'
    UPUK retries: '0'
  Application [1]:
    Application type:  'usim (2)'
    Application state: 'ready'
    Application ID:
      A0:00:00:00:87:10:02:FF:49:FF:05:89
    Personalization state: 'ready'
    UPIN replaces PIN1: 'no'
    PIN1 state: 'enabled-verified'
      PIN1 retries: '3'
      PUK1 retries: '10'
    PIN2 state: 'enabled-not-verified'
      PIN2 retries: '3'
      PUK2 retries: '10'
  Application [2]:
    Application type:  'unknown (0)'
    Application state: 'detected'
    Application ID:
      A0:00:00:00:63:50:4B:43:53:2D:31:35
    Personalization state: 'unknown'
    UPIN replaces PIN1: 'no'
    PIN1 state: 'not-initialized'
      PIN1 retries: '0'
      PUK1 retries: '0'
    PIN2 state: 'not-initialized'
      PIN2 retries: '0'
      PUK2 retries: '0'
Slot [2]:
  Card state: 'error: no-atr-received (3)'
  UPIN state: 'not-initialized'
    UPIN retries: '0'
    UPUK retries: '0'
```
If anyone knows qmicli well, any help getting further would be appreciated.