### PR TITLE
Some changes for Qgauge driver

### DIFF
--- a/arch/arm64/boot/dts/qcom/pm6150.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm6150.dtsi
@@ -167,6 +167,8 @@
 			io-channel-names = "batt-therm",
 					   "batt-id";
 
+			nvmem = <&pm6150_qg_sdam>;
+
 			status = "disabled";
 		};
 
@@ -176,6 +178,14 @@
 			reg-names = "rtc", "alarm";
 			interrupts = <0x0 0x61 0x1 IRQ_TYPE_EDGE_RISING>;
 			status = "disabled";
+		};
+
+		pm6150_qg_sdam: nvram@b600 {
+			compatible = "qcom,spmi-sdam";
+			reg = <0xb600>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0 0xb600 0x100>;
 		};
 
 		pm6150_gpios: gpio@c000 {

--- a/drivers/power/supply/qcom_qg.c
+++ b/drivers/power/supply/qcom_qg.c
@@ -3,14 +3,14 @@
  * Copyright (c) 2024, Danila Tikhonov <danila@jiaxyga.com>
  */
 
-#include <linux/module.h>
-#include <linux/kernel.h>
+#include <linux/iio/consumer.h>
 #include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
 #include <linux/of_address.h>
 #include <linux/platform_device.h>
-#include <linux/of.h>
 #include <linux/power_supply.h>
-#include <linux/iio/consumer.h>
 #include <linux/regmap.h>
 
 /* SRAM */

--- a/drivers/power/supply/qcom_qg.c
+++ b/drivers/power/supply/qcom_qg.c
@@ -193,7 +193,7 @@ static int qcom_qg_probe(struct platform_device *pdev)
 	chip->dev = &pdev->dev;
 
 	/* Regmap */
-	chip->regmap = dev_get_regmap(pdev->dev.parent, NULL);
+	chip->regmap = dev_get_regmap(chip->dev->parent, NULL);
 	if (!chip->regmap)
 		return dev_err_probe(chip->dev, -ENODEV,
 				     "Failed to locate the regmap\n");
@@ -205,13 +205,13 @@ static int qcom_qg_probe(struct platform_device *pdev)
 				     "Couldn't read base address\n");
 
 	/* ADC for thermal channel */
-	chip->batt_therm_chan = devm_iio_channel_get(&pdev->dev, "batt-therm");
+	chip->batt_therm_chan = devm_iio_channel_get(chip->dev, "batt-therm");
 	if (IS_ERR(chip->batt_therm_chan))
 		return dev_err_probe(chip->dev, PTR_ERR(chip->batt_therm_chan),
 				     "Couldn't get batt-therm IIO channel\n");
 
 	psy_cfg.drv_data = chip;
-	psy_cfg.of_node = pdev->dev.of_node;
+	psy_cfg.of_node = chip->dev->of_node;
 
 	/* Power supply */
 	chip->batt_psy =

--- a/drivers/power/supply/qcom_qg.c
+++ b/drivers/power/supply/qcom_qg.c
@@ -7,14 +7,12 @@
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/nvmem-consumer.h>
 #include <linux/of.h>
 #include <linux/of_address.h>
 #include <linux/platform_device.h>
 #include <linux/power_supply.h>
 #include <linux/regmap.h>
-
-/* SRAM */
-#define QG_SRAM_BASE	0xb600
 
 /* BATT offsets */
 #define QG_S2_NORMAL_AVG_V_DATA0_REG	0x80 /* 2-byte 0x80-0x81 */
@@ -33,6 +31,8 @@ struct qcom_qg_chip {
 
 	struct iio_channel *batt_therm_chan;
 	struct iio_channel *batt_id_chan;
+
+	struct nvmem_device *sdam;
 
 	struct power_supply *batt_psy;
 	struct power_supply_battery_info *batt_info;
@@ -77,9 +77,8 @@ static int qcom_qg_get_capacity(struct qcom_qg_chip *chip, int *val)
 {
 	int ret, temp, ocv;
 
-	ret = regmap_raw_read(chip->regmap,
-			QG_SRAM_BASE + QG_SDAM_OCV_OFFSET, &ocv, 4);
-	if (ret) {
+	ret = nvmem_device_read(chip->sdam, QG_SDAM_OCV_OFFSET, 4, &ocv);
+	if (ret < 0) {
 		dev_err(chip->dev,
 			"Failed to get open-circuit voltage: %d\n", ret);
 		return ret;
@@ -143,9 +142,8 @@ static int qcom_qg_get_property(struct power_supply *psy,
 			return ret;
 		break;
 	case POWER_SUPPLY_PROP_VOLTAGE_OCV:
-		ret = regmap_raw_read(chip->regmap,
-			QG_SRAM_BASE + QG_SDAM_OCV_OFFSET, &val->intval, 4);
-		if (ret)
+		ret = nvmem_device_read(chip->sdam, QG_SDAM_OCV_OFFSET, 4, &val->intval);
+		if (ret < 0)
 			return ret;
 		break;
 	case POWER_SUPPLY_PROP_CURRENT_NOW:
@@ -164,9 +162,9 @@ static int qcom_qg_get_property(struct power_supply *psy,
 		val->intval = chip->batt_info->charge_full_design_uah;
 		break;
 	case POWER_SUPPLY_PROP_CHARGE_FULL:
-		ret = regmap_raw_read(chip->regmap, QG_SRAM_BASE +
-				QG_SDAM_LEARNED_CAPACITY_OFFSET, &val->intval, 2);
-		if (ret)
+		ret = nvmem_device_read(chip->sdam,
+				QG_SDAM_LEARNED_CAPACITY_OFFSET, 2, &val->intval);
+		if (ret < 0)
 			return ret;
 		val->intval *= 1000; /* mAh to uAh */
 		break;
@@ -226,6 +224,12 @@ static int qcom_qg_probe(struct platform_device *pdev)
 	if (IS_ERR(chip->batt_therm_chan))
 		return dev_err_probe(chip->dev, PTR_ERR(chip->batt_therm_chan),
 				     "Couldn't get batt-therm IIO channel\n");
+
+	/* NVMEM for SDAM access */
+	chip->sdam = devm_nvmem_device_get(chip->dev, NULL);
+	if (IS_ERR(chip->sdam))
+		return dev_err_probe(chip->dev, PTR_ERR(chip->sdam),
+				     "Couldn't get SDAM nvmem device\n");
 
 	psy_cfg.drv_data = chip;
 	psy_cfg.of_node = chip->dev->of_node;

--- a/drivers/power/supply/qcom_qg.c
+++ b/drivers/power/supply/qcom_qg.c
@@ -180,6 +180,7 @@ static int qcom_qg_get_property(struct power_supply *psy,
 					(chip->batt_therm_chan, &val->intval);
 		if (ret < 0)
 			return ret;
+		val->intval /= 100; /* 1/1000 °C (millidegC) to 1/10 °C */
 		break;
 	default:
 		dev_err(chip->dev, "invalid property: %d\n", psp);

--- a/drivers/power/supply/qcom_qg.c
+++ b/drivers/power/supply/qcom_qg.c
@@ -133,22 +133,32 @@ static int qcom_qg_get_property(struct power_supply *psy,
 	case POWER_SUPPLY_PROP_VOLTAGE_NOW:
 		ret = qcom_qg_get_voltage(chip,
 				QG_LAST_ADC_V_DATA0_REG, &val->intval);
+		if (ret)
+			return ret;
 		break;
 	case POWER_SUPPLY_PROP_VOLTAGE_AVG:
 		ret = qcom_qg_get_voltage(chip,
 				QG_S2_NORMAL_AVG_V_DATA0_REG, &val->intval);
+		if (ret)
+			return ret;
 		break;
 	case POWER_SUPPLY_PROP_VOLTAGE_OCV:
 		ret = regmap_raw_read(chip->regmap,
 			QG_SRAM_BASE + QG_SDAM_OCV_OFFSET, &val->intval, 4);
+		if (ret)
+			return ret;
 		break;
 	case POWER_SUPPLY_PROP_CURRENT_NOW:
 		ret = qcom_qg_get_current(chip,
 				QG_LAST_ADC_I_DATA0_REG, &val->intval);
+		if (ret)
+			return ret;
 		break;
 	case POWER_SUPPLY_PROP_CURRENT_AVG:
 		ret = qcom_qg_get_current(chip,
 				QG_S2_NORMAL_AVG_I_DATA0_REG, &val->intval);
+		if (ret)
+			return ret;
 		break;
 	case POWER_SUPPLY_PROP_CHARGE_FULL_DESIGN:
 		val->intval = chip->batt_info->charge_full_design_uah;
@@ -156,14 +166,20 @@ static int qcom_qg_get_property(struct power_supply *psy,
 	case POWER_SUPPLY_PROP_CHARGE_FULL:
 		ret = regmap_raw_read(chip->regmap, QG_SRAM_BASE +
 				QG_SDAM_LEARNED_CAPACITY_OFFSET, &val->intval, 2);
-		if (!ret) val->intval *= 1000; /* mah to uah */
+		if (ret)
+			return ret;
+		val->intval *= 1000; /* mAh to uAh */
 		break;
 	case POWER_SUPPLY_PROP_CAPACITY:
 		ret = qcom_qg_get_capacity(chip, &val->intval);
+		if (ret)
+			return ret;
 		break;
 	case POWER_SUPPLY_PROP_TEMP:
 		ret = iio_read_channel_processed
 					(chip->batt_therm_chan, &val->intval);
+		if (ret < 0)
+			return ret;
 		break;
 	default:
 		dev_err(chip->dev, "invalid property: %d\n", psp);


### PR DESCRIPTION
Notably stop hardcoding the SDAM address and instead of the qcom,spmi-sdam driver and access the SDAM via the nvmem framework.

Please test on pm6150 if this works as expected, the driver seems to need some changes for pm7250b to get ocv values there, we just get 0.