### PR TITLE
arm64: dts: qcom: sunfish: enable QG fuel gauge + SMB2 charger

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm7150-google-sunfish.dts
+++ b/arch/arm64/boot/dts/qcom/sm7150-google-sunfish.dts
@@ -651,6 +651,26 @@
 	status = "okay";
 };
 
+/ {
+	battery: battery {
+		compatible = "simple-battery";
+		charge-full-design-microamp-hours = <3140000>;
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4400000>;
+		constant-charge-current-max-microamp = <2000000>;
+	};
+};
+
+&pm6150_charger {
+	monitored-battery = <&battery>;
+	status = "okay";
+};
+
+&pm6150_qgauge {
+	monitored-battery = <&battery>;
+	status = "okay";
+};
+
 &pm6150_typec {
 	vdd-vbus-supply = <&pm6150_vbus>;
 	vdd-pdphy-supply = <&vdda_usb_hs_3p1>;


### PR DESCRIPTION
Enable the PM6150 QGauge (fuel gauge) and SMB2 charger on the Pixel 4a (sunfish).
Both nodes already exist in `pm6150.dtsi` but are disabled and require a
`monitored-battery`; this adds a `simple-battery` describing the Pixel 4a's
3140 mAh cell and enables the charger + qgauge.

With this, userspace gets battery capacity / voltage / current / temperature
and charge status + online via the standard power_supply class.

Tested on a Pixel 4a on postmarketOS with a mainline kernel from this tree:
`/sys/class/power_supply/*` reports capacity, voltage_now, current_now, temp
and status (Charging/Discharging) as expected.
