### PR TITLE
arm64: dts: qcom: sm7150-xiaomi-sweet: add IR blaster on SPI8

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm7150-xiaomi-sweet.dts
+++ b/arch/arm64/boot/dts/qcom/sm7150-xiaomi-sweet.dts
@@ -258,6 +258,16 @@
 	status = "okay";
 };
 
+&spi8 {
+	status = "okay";
+
+	irled@0 {
+		compatible = "ir-spi-led";
+		reg = <0>;
+		spi-max-frequency = <19200000>;
+	};
+};
+
 &tlmm {
 	amp_t_int_default: amp-t-int-default-state {
 		pins = "gpio93";


### PR DESCRIPTION
The Redmi Note 10 Pro has a consumer IR LED on QUPv3 SE8 in SPI mode
(spi@a88000), as described by downstream sweet-sdmmagpie.dtsi. SE8 is
shared with uart8, which sweet already disables, so enabling spi8
introduces no conflict.

Add the ir-spi-led node. /dev/lirc0 is registered and transmits, but the
range is short. The carrier is not at fault: spi-geni-qcom reports 607594 Hz
for the 608000 Hz requested, a 0.07% error. The shared qup_spi8_spi pinctrl
state sets no drive-strength and so defaults to 2 mA, which is the remaining
suspect; a fix belongs in a follow-up patch.

Signed-off-by: Simon Cederborg <m8l8th814n-eng@users.noreply.github.com>
