### PR TITLE
arm64: dts: qcom: sunfish: enable PM6150 fuel gauge + charging

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm7150-google-sunfish.dts
+++ b/arch/arm64/boot/dts/qcom/sm7150-google-sunfish.dts
@@ -658,8 +658,14 @@
 	status = "okay";
 };
 
+&pm6150_charger {
+	monitored-battery = <&battery>;
+	status = "okay";
+};
+
 &pm6150_qgauge {
 	monitored-battery = <&battery>;
+	power-supplies = <&pm6150_charger>;
 	status = "okay";
 };
 
@@ -680,12 +686,17 @@
 	connector {
 		compatible = "usb-c-connector";
 
-		power-role = "source";
+		op-sink-microwatt = <10000000>;
+		power-role = "dual";
 		data-role = "dual";
 		self-powered;
 
 		source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_DUAL_ROLE |
 			       PDO_FIXED_USB_COMM | PDO_FIXED_DATA_SWAP)>;
+
+		sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_DUAL_ROLE |
+			     PDO_FIXED_USB_COMM | PDO_FIXED_DATA_SWAP)
+			     PDO_VAR(5000, 9000, 3000)>;
 
 		ports {
 			#address-cells = <1>;

--- a/arch/arm64/boot/dts/qcom/sm7150-google-sunfish.dts
+++ b/arch/arm64/boot/dts/qcom/sm7150-google-sunfish.dts
@@ -74,6 +74,22 @@
 		};
 	};
 
+	/*
+	 * Values match Google's downstream sunfish ATL/LSN cell profiles
+	 * (3080 mAh, 4.45 V max, 3.30 V min). The downstream kernel
+	 * dynamically selects per-cell profiles via a battery-ID resistor;
+	 * the DT-only path here picks the original pack data shared by
+	 * both vendors. Phones whose LSN cells received the post-incident
+	 * software mitigation (max charge limited to 3.95 V) will see
+	 * qcom_qg's voltage-based SOC plateau well below 100 %.
+	 */
+	battery: battery {
+		compatible = "simple-battery";
+		voltage-min-design-microvolt = <3300000>;
+		voltage-max-design-microvolt = <4450000>;
+		charge-full-design-microamp-hours = <3080000>;
+	};
+
 	reserved-memory {
 		mpss_mem: memory@8b000000 {
 			reg = <0x0 0x8b000000 0x0 0x9800000>;
@@ -639,6 +655,11 @@
 
 &mdss_dsi0_phy {
 	vdds-supply = <&vdda_mipi_dsi0_pll>;
+	status = "okay";
+};
+
+&pm6150_qgauge {
+	monitored-battery = <&battery>;
 	status = "okay";
 };
 

--- a/drivers/power/supply/qcom_qg.c
+++ b/drivers/power/supply/qcom_qg.c
@@ -131,7 +131,9 @@ static int qcom_qg_get_property(struct power_supply *psy,
 
 	switch (psp) {
 	case POWER_SUPPLY_PROP_STATUS:
-		val->intval = POWER_SUPPLY_STATUS_UNKNOWN;
+		val->intval = power_supply_am_i_supplied(psy) ?
+			POWER_SUPPLY_STATUS_CHARGING :
+			POWER_SUPPLY_STATUS_DISCHARGING;
 		break;
 	case POWER_SUPPLY_PROP_TECHNOLOGY:
 		val->intval = POWER_SUPPLY_TECHNOLOGY_LION;


### PR DESCRIPTION
Enables the PM6150 fuel gauge and SMB2 charger on sunfish. Added a simple-battery node with the downstream 3080mAh ATL/LSN pack data and wired the charger into the gauge and the Type-C connector so TCPM actually draws power. Also makes qcom_qg report charging/discharging status instead of always UNKNOWN, using power_supply_am_i_supplied().

Tested on two 4a units running mainline from this tree, mine and @truongsinh's independently. Capacity/voltage/current/temp all show up under /sys/class/power_supply/qcom_qg and charging status tracks the cable correctly.
