### PR TITLE
media: qcom: camss: sm7150: raise the interconnect bandwidth request

### DIFF
--- a/drivers/media/platform/qcom/camss/camss.c
+++ b/drivers/media/platform/qcom/camss/camss.c
@@ -2141,26 +2141,39 @@ static const struct camss_subdev_resources vfe_res_7150[] = {
 	},
 };
 
+/*
+ * Twice the figure the rest of this file carries. On this platform the smaller
+ * one is not enough: the fastest of the four sensors, 2592x1940 raw at 30 fps,
+ * loses CSI-2 lane FIFOs to overflow within a few frames whenever the CPU is
+ * also working the memory, and the receiver takes the whole stream down with
+ * it. Measured on the device, one run of that sensor per step: 2 GiB/s and
+ * 3 GiB/s both fail, 4 GiB/s and 6 GiB/s both run clean.
+ *
+ * Note the ratio this is not: the sensor itself writes some 190 MB/s, twenty
+ * times less than what it takes to keep it alive. The request is not paying for
+ * the camera's own traffic, it is asking the fabric and the DDR behind it to
+ * run at a point where a busy memory bus still leaves the receiver served.
+ */
 static const struct resources_icc icc_res_sm7150[] = {
 	{
 		.name = "cam_ahb",
-		.icc_bw_tbl.avg = 60000,
-		.icc_bw_tbl.peak = 120000,
+		.icc_bw_tbl.avg = 120000,
+		.icc_bw_tbl.peak = 240000,
 	},
 	{
 		.name = "cam_hf_0_mnoc",
-		.icc_bw_tbl.avg = 2097152,
-		.icc_bw_tbl.peak = 2097152,
+		.icc_bw_tbl.avg = 4194304,
+		.icc_bw_tbl.peak = 4194304,
 	},
 	{
 		.name = "cam_sf_0_mnoc",
 		.icc_bw_tbl.avg = 0,
-		.icc_bw_tbl.peak = 2097152,
+		.icc_bw_tbl.peak = 4194304,
 	},
 	{
 		.name = "cam_sf_icp_mnoc",
-		.icc_bw_tbl.avg = 2097152,
-		.icc_bw_tbl.peak = 2097152,
+		.icc_bw_tbl.avg = 4194304,
+		.icc_bw_tbl.peak = 4194304,
 	},
 };
 


### PR DESCRIPTION
## media: qcom: camss: sm7150: raise the interconnect bandwidth request

### Problem

On the Xiaomi Mi 9T (`xiaomi,davinci`) the front sensor, S5K3T2 at 2592x1940 raw10
30 fps, dies within a few seconds of streaming whenever the CPU is also working the
memory — which on this device means any time libcamera's software debayer is running.

The visible failure is a stalled pipeline: userspace stops getting buffers and the
camera application hangs. The kernel log shows CSI-2 lane FIFO overflow on the
receiver (`CSID_CSI2_RX_IRQ_STATUS = 0x01dbc0ff`: lane 0/1/2 overflow, CRC and ECC
errors, incomplete frame), followed by IOMMU context faults from the write master.

The faults are a symptom. Measured during a stall: the pipeline was hung for 31
seconds without a single new fault, while faults appeared before and after the
window. The receiver dies first; the write master runs on afterwards.

### Root cause

`icc_res_sm7150` asks the fabric for 2 GiB/s, applied once in `camss_runtime_resume()`
and dropped on power down. Sampling during a live stall confirms the request never
changes and the CAMNOC clock stays where `vfe_set_clock_rates()` puts it.

### Measurements

One run of that sensor per step, on the device, nothing else changed:

| interconnect request | CAMNOC clock | result |
|---|---|---|
| 2 GiB/s (current) | 150 MHz | stalls within seconds |
| 3 GiB/s | 150 MHz | stalls within seconds |
| **4 GiB/s** | 150 MHz | **runs clean, 0 IOMMU faults** |
| 6 GiB/s | 150 MHz | runs clean, 0 IOMMU faults |
| 2 GiB/s | 320 MHz | stalls within seconds |
| 6 GiB/s | 320 MHz | runs clean, 0 IOMMU faults |

The last two rows separate the two resources: raising the CAMNOC clock with the old
request changes nothing, raising the request with the stock clock fixes it. This patch
therefore touches only the request; `vfe_set_clock_rates()` is left alone.

After the change, with no module parameters and nothing else tuned: 15 camera sessions,
0 context faults, 0 VFE/CSID errors.

### Why the number is not derived from the stream

The sensor writes about 190 MB/s (2592 × 1940 × 10 bits × 30 fps). The request that
keeps it alive is twenty times that. So this is not paying for the camera's own
traffic — it asks the fabric and the DDR behind it to run at an operating point where
a busy memory bus still leaves the receiver served.

Worth stating explicitly, because the obvious "improvement" would make things worse: a
bandwidth model computed from resolution × frame rate × bits would request ~0.2 GB/s,
below even the current value.

### Note on the constant being replaced

`2097152` is not a measured figure for sm7150 — the identical constant appears for
2290, sm6150, sm6350, sm8250 and the other platforms in this file. Mainline
`icc_res_sm6150` carries the same value; whether that platform has the same problem is
untested here, and this patch does not touch it.

### What was tested

- Device: Xiaomi Mi 9T (`xiaomi,davinci`), postmarketOS, kernel `7.1.0-sm7150` from
  this branch at `fd78d17954a8`.
- Sensors exercised: front S5K3T2 through `csiphy1 → csid0 → vfe0_rdi0`, rear OV8856
  through `csiphy3`.
- Both libcamera (Plasma Camera) and raw V4L2 via `media-ctl` + `v4l2-ctl`.

### Known limitations

- All four interconnect paths are scaled together, because the experiment scaled them
  together. Which single path carries the fix, and whether `avg` or `peak` is the one
  that matters, is not separated.
- One run per step of the ladder; no long soak and no cold-boot series yet.
- Only davinci was available. Other sm7150 devices are untested.

Happy to run further measurements on request — the device is on the bench.
