### PR TITLE
arm64: dts: qcom: sm7150-xiaomi-davinci: working WCD9375 microphone capture

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dtsi
@@ -604,8 +604,23 @@
 		compatible = "sdw20217010a00";
 		reg = <0 3>;
 
-		qcom,tx-port-mapping = <2 3 4 5>;\
-		qcom,tx-channel-mapping = /bits/ 8 <1 1 2 1 2 4 1 2 4 8>;
+		/*
+		 * Port topology belongs to the codec itself:
+		 *   TX Port 1 (ADC1)                <=> SWR Port 2
+		 *   TX Port 2 (ADC2, ADC3)          <=> SWR Port 2
+		 *   TX Port 3 (DMIC0..3 and MBHC)   <=> SWR Port 3
+		 *   TX Port 4 (DMIC4..7)            <=> SWR Port 4
+		 * Twelve channels: adc1, adc2, adc3, dmic0, dmic1, mbhc,
+		 * dmic2, dmic3, dmic4, dmic5, dmic6, dmic7.
+		 *
+		 * The master port numbers differ by one from qcm6490-idp,
+		 * which uses <1 1 2 3>: the driver looks the port config up
+		 * as pconfig[m_port], and the sm7150 TX controller has one
+		 * dout port, so the microphone inputs start at port 2 - which
+		 * is also why the qcom,ports-* arrays of swr2 begin with 0xff.
+		 */
+		qcom,tx-port-mapping = <2 2 3 4>;
+		qcom,tx-channel-mapping = /bits/ 8 <1 2 1 1 2 3 3 4 1 2 3 4>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dtsi
@@ -112,6 +112,33 @@
 		};
 	};
 
+	/*
+	 * WCD9375. Reset is LPI pin 6 - the vendor tree calls it 24, counting
+	 * from a base 0x12000 lower than the one mainline uses. Supplies are
+	 * taken from the vendor tree for this board: L10A for the rxtx and px
+	 * rails, L15A for the buck, BOB for the mic bias.
+	 */
+	wcd9375: audio-codec-0 {
+		compatible = "qcom,wcd9375-codec";
+
+		reset-gpios = <&lpass_tlmm 6 GPIO_ACTIVE_LOW>;
+
+		vdd-buck-supply = <&vreg_l15a_1p8>;
+		vdd-rxtx-supply = <&vreg_l10a_1p8>;
+		vdd-px-supply = <&vreg_l10a_1p8>;
+		vdd-mic-bias-supply = <&vreg_bob>;
+
+		/* From the vendor tree: 2750/1800/2750 mV, not all the same */
+		qcom,micbias1-microvolt = <2750000>;
+		qcom,micbias2-microvolt = <1800000>;
+		qcom,micbias3-microvolt = <2750000>;
+
+		qcom,rx-device = <&wcd_rx>;
+		qcom,tx-device = <&wcd_tx>;
+
+		#sound-dai-cells = <1>;
+	};
+
 	camt_avdd_2p8: regulator-camt-avdd-2p8 {
 		compatible = "regulator-fixed";
 		regulator-name = "camt_avdd_2p8";

--- a/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dtsi
@@ -586,6 +586,41 @@
 	};
 };
 
+&swr1 {
+	status = "okay";
+
+	wcd_rx: codec@0,4 {
+		compatible = "sdw20217010a00";
+		reg = <0 4>;
+
+		qcom,rx-port-mapping = <1 2 3 4 5>;
+		qcom,rx-channel-mapping = /bits/ 8 <1 2 1 1 2 1 1 2>;
+	};
+};
+
+&swr2 {
+	status = "okay";
+	wcd_tx: codec@0,3 {
+		compatible = "sdw20217010a00";
+		reg = <0 3>;
+
+		qcom,tx-port-mapping = <2 3 4 5>;\
+		qcom,tx-channel-mapping = /bits/ 8 <1 1 2 1 2 4 1 2 4 8>;
+	};
+};
+
+&vamacro {
+	status = "okay";
+};
+
+&txmacro {
+	status = "okay";
+};
+
+&rxmacro {
+	status = "okay";
+};
+
 &venus {
 	firmware-name = "qcom/sm7150/xiaomi/davinci/venus.mbn";
 };

--- a/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm7150-xiaomi-davinci.dtsi
@@ -89,10 +89,85 @@
 		pinctrl-names = "default";
 		model = "Xiaomi Mi 9T";
 
+		/*
+		 * Matches the vendor tree. Note the ADCs sit on SoundWire
+		 * inputs 0 and 2, not on consecutive ones. The vendor also
+		 * lists "MIC BIAS" -> "Analog MicN" links, but no such widgets
+		 * exist in the mainline codec driver.
+		 */
+		audio-routing = "AMIC1", "MIC BIAS1",
+				"AMIC2", "MIC BIAS2",
+				"AMIC3", "MIC BIAS3",
+				"TX SWR_ADC0", "ADC1_OUTPUT",
+				"TX SWR_ADC2", "ADC2_OUTPUT";
+
 		mm1-dai-link {
 			link-name = "MultiMedia1";
 			cpu {
 				sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA1>;
+			};
+		};
+
+		/*
+		 * Capture needs a frontend of its own. With only MultiMedia1
+		 * both directions share a single PCM, and capture cannot set
+		 * hw params while playback is running, so userspace can never
+		 * have a source and a sink at the same time. Other boards do
+		 * the same, e.g. Qualcomm RB5 plays on MultiMedia2 and
+		 * captures on MultiMedia3.
+		 */
+		mm2-dai-link {
+			link-name = "MultiMedia2";
+			cpu {
+				sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA2>;
+			};
+		};
+
+		/*
+		 * Capture through the WCD9375: the analogue mics reach the
+		 * codec's own ADCs and come back over the TX SoundWire bus,
+		 * the digital mics wired to the LPASS go through the VA macro.
+		 */
+		wcd-capture-dai-link {
+			link-name = "WCD Capture";
+
+			cpu {
+				sound-dai = <&q6afedai TX_CODEC_DMA_TX_3>;
+			};
+
+			platform {
+				sound-dai = <&q6routing>;
+			};
+
+			/*
+			 * Use DAI 1 of swr2, not DAI 0. The controller registers
+			 * one DAI per port and assigns the direction by index
+			 * (qcom_swrm_register_dais()): the first num_dout_ports
+			 * DAIs are playback only, the rest are capture only.
+			 * The sm7150 TX controller has one dout port, so "SDW
+			 * Pin0" is playback and never gets hw_params in a capture
+			 * link - and sdw_stream_add_master() is called from there,
+			 * leaving the master ports unprogrammed. qcm6490-idp can
+			 * use <&swr1 0> because its TX controller has no dout port.
+			 */
+			codec {
+				sound-dai = <&wcd9375 1>, <&swr2 1>, <&txmacro 0>;
+			};
+		};
+
+		va-dai-link {
+			link-name = "VA Capture";
+
+			cpu {
+				sound-dai = <&q6afedai VA_CODEC_DMA_TX_0>;
+			};
+
+			platform {
+				sound-dai = <&q6routing>;
+			};
+
+			codec {
+				sound-dai = <&vamacro 0>;
 			};
 		};
 

--- a/arch/arm64/boot/dts/qcom/sm7150.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm7150.dtsi
@@ -4688,7 +4688,18 @@
 			reg = <0 0x62ed0000 0 0x2000>;
 			compatible = "qcom,soundwire-v1.5.1";
 			status = "disabled";
-			interrupts = <GIC_SPI 296 IRQ_TYPE_LEVEL_HIGH>;
+			/*
+			 * The TX bus needs the second, wakeup interrupt: capture
+			 * traffic originates at the codec, so the bus has to wake
+			 * itself. Without it the SoundWire device never leaves
+			 * runtime suspend, regmap-irq keeps reporting "IRQ sync
+			 * failed to resume" and the sound card fails to probe.
+			 * The RX bus does not need it - it is woken by the
+			 * playback side.
+			 */
+			interrupts = <GIC_SPI 296 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 500 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "core", "wakeup";
 
 			clocks = <&txmacro>;
 			clock-names = "iface";

--- a/arch/arm64/boot/dts/qcom/sm7150.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm7150.dtsi
@@ -4664,6 +4664,119 @@
 			status = "disabled";
 		};
 
+		txmacro: txmacro@62ec0000 {
+			compatible = "qcom,sm7150-lpass-tx-macro",
+				     "qcom,sm8250-lpass-tx-macro";
+			reg = <0 0x62ec0000 0 0x1000>;
+
+			clocks = <&q6afecc LPASS_CLK_ID_TX_CORE_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
+				 <&q6afecc LPASS_CLK_ID_TX_CORE_NPL_MCLK  LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
+				 <&q6afecc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
+				 <&vamacro>;
+			clock-names = "mclk", "npl", "macro", "fsgen";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&tx_swr_active>;
+
+			#clock-cells = <0>;
+			clock-output-names = "mclk";
+			#sound-dai-cells = <1>;
+			status = "disabled";
+		};
+
+		swr2: soundwire-controller@62ed0000 {
+			reg = <0 0x62ed0000 0 0x2000>;
+			compatible = "qcom,soundwire-v1.5.1";
+			status = "disabled";
+			interrupts = <GIC_SPI 296 IRQ_TYPE_LEVEL_HIGH>;
+
+			clocks = <&txmacro>;
+			clock-names = "iface";
+			label = "TX";
+
+			qcom,din-ports = <6>;
+			qcom,dout-ports = <1>;
+			qcom,ports-sinterval-low =		/bits/ 8 <0xff 0x01 0x01 0x03 0x03 0xff 0xff>;
+			qcom,ports-offset1 =			/bits/ 8 <0xff 0x01 0x00 0x01 0x00 0xff 0xff>;
+			qcom,ports-offset2 =			/bits/ 8 <0xff 0x00 0x00 0x00 0x00 0xff 0xff>;
+			qcom,ports-hstart =			/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
+			qcom,ports-hstop =			/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
+			qcom,ports-word-length =		/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
+			qcom,ports-block-pack-mode =		/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
+			qcom,ports-block-group-count =		/bits/ 8 <0xff 0xff 0xff 0xff 0xff 0xff 0xff>;
+			qcom,ports-lane-control =		/bits/ 8 <0xff 0x00 0x01 0x00 0x01 0xff 0xff>;
+
+			#sound-dai-cells = <1>;
+			#address-cells = <2>;
+			#size-cells = <0>;
+		};
+
+		rxmacro: rxmacro@62ee0000 {
+			compatible = "qcom,sm7150-lpass-rx-macro",
+				     "qcom,sm8250-lpass-rx-macro";
+			reg = <0 0x62ee0000 0 0x1000>;
+
+			clocks = <&q6afecc LPASS_CLK_ID_TX_CORE_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
+				 <&q6afecc LPASS_CLK_ID_TX_CORE_NPL_MCLK  LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
+				 <&q6afecc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
+				 <&vamacro>;
+			clock-names = "mclk", "npl", "macro", "fsgen";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&rx_swr_active>;
+
+			#clock-cells = <0>;
+			clock-output-names = "mclk";
+			#sound-dai-cells = <1>;
+		};
+
+
+		swr1: soundwire-controller@62ef0000 {
+			reg = <0 0x62ef0000 0 0x2000>;
+			compatible = "qcom,soundwire-v1.5.1";
+			status = "disabled";
+			interrupts = <GIC_SPI 297 IRQ_TYPE_LEVEL_HIGH>;
+
+			clocks = <&rxmacro>;
+			clock-names = "iface";
+			label = "RX";
+
+			qcom,din-ports = <1>;
+			qcom,dout-ports = <6>;
+
+			qcom,ports-sinterval-low =      /bits/ 8 <0x03 0x1f 0x1f 0x07 0x00 0xff 0xff>;
+			qcom,ports-offset1 =            /bits/ 8 <0x00 0x00 0x0b 0x01 0x00 0xff 0xff>;
+			qcom,ports-offset2 =            /bits/ 8 <0x00 0x00 0x0b 0x00 0x00 0xff 0xff>;
+			qcom,ports-hstart =             /bits/ 8 <0xff 0x03 0xff 0xff 0xff 0xff 0xff>;
+			qcom,ports-hstop =              /bits/ 8 <0xff 0x06 0xff 0xff 0xff 0xff 0xff>;
+			qcom,ports-word-length =        /bits/ 8 <0x01 0x07 0x04 0xff 0xff 0xff 0xff>;
+			qcom,ports-block-pack-mode =    /bits/ 8 <0xff 0x00 0x01 0xff 0xff 0xff 0xff>;
+			qcom,ports-block-group-count =  /bits/ 8 <0xff 0xff 0xff 0xff 0x00 0xff 0xff>;
+			qcom,ports-lane-control =       /bits/ 8 <0x01 0x00 0x00 0x00 0x00 0xff 0xff>;
+
+			#sound-dai-cells = <1>;
+			#address-cells = <2>;
+			#size-cells = <0>;
+		};
+
+		vamacro: codec@62f20000 {
+			compatible = "qcom,sm7150-lpass-va-macro",
+				     "qcom,sm8250-lpass-va-macro";
+			reg = <0 0x62f20000 0 0x1000>;
+
+			clocks = <&q6afecc LPASS_CLK_ID_TX_CORE_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
+				 <&q6afecc LPASS_CLK_ID_TX_CORE_NPL_MCLK LPASS_CLK_ATTRIBUTE_COUPLE_NO>,
+				 <&q6afecc LPASS_HW_MACRO_VOTE LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
+			clock-names = "mclk", "npl", "macro";
+
+			qcom,dmic-sample-rate = <2400000>; // insisted by the controller
+			vdd-micb-supply = <&vreg_l15a_1p8>; // insisted by the controller
+
+			#clock-cells = <0>;
+			clock-output-names = "fsgen";
+			#sound-dai-cells = <1>;
+		};
+
 		lpass_tlmm: pinctrl@62b52000 {
 			compatible = "qcom,sm7150-lpass-lpi-pinctrl";
 			/* SSC range: <0 0x62b40000 0 0x12000> */

--- a/arch/arm64/boot/dts/qcom/sm7150.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm7150.dtsi
@@ -4739,6 +4739,8 @@
 			#clock-cells = <0>;
 			clock-output-names = "mclk";
 			#sound-dai-cells = <1>;
+
+			status = "disabled";
 		};
 
 
@@ -4786,6 +4788,8 @@
 			#clock-cells = <0>;
 			clock-output-names = "fsgen";
 			#sound-dai-cells = <1>;
+
+			status = "disabled";
 		};
 
 		lpass_tlmm: pinctrl@62b52000 {

--- a/drivers/pinctrl/qcom/pinctrl-sm7150-lpass-lpi.c
+++ b/drivers/pinctrl/qcom/pinctrl-sm7150-lpass-lpi.c
@@ -92,7 +92,15 @@ static const struct lpi_pingroup sm7150_groups[] = {
 	LPI_PINGROUP(2, 4, slimbus_data, swr_tx_data, _, _),
 	LPI_PINGROUP(3, 8, slimbus_data, swr_rx_clk, _, _),
 	LPI_PINGROUP(4, 10, slimbus_data, swr_rx_data, prim_mclk_a, _),
-	LPI_PINGROUP(5, 6, qua_mi2s_sclk, _, swr_rx_data, swr_tx_data),
+	/*
+	 * Same off-by-one slot as GPIO1 above, on the second SoundWire RX data
+	 * line: the vendor tree programs func2 for gpio23, while listing
+	 * swr_rx_data third here makes the driver select 3. The bus enumerates
+	 * either way, so this only shows up once playback data actually flows -
+	 * the controller then reports MASTER_CLASH_DET and the stream dies
+	 * after a fraction of a second.
+	 */
+	LPI_PINGROUP(5, 6, qua_mi2s_sclk, swr_rx_data, _, swr_tx_data),
 	LPI_PINGROUP(6, LPI_NO_SLEW, qua_mi2s_ws, cdc_pdm_rx, _, _),
 	LPI_PINGROUP(7, LPI_NO_SLEW, qua_mi2s_data, _, _, _),
 	LPI_PINGROUP(8, LPI_NO_SLEW, qua_mi2s_data, dmic1_clk, _, _),

--- a/drivers/pinctrl/qcom/pinctrl-sm7150-lpass-lpi.c
+++ b/drivers/pinctrl/qcom/pinctrl-sm7150-lpass-lpi.c
@@ -81,7 +81,14 @@ static const char * const swr_tx_data_groups[] = { "gpio1", "gpio2", "gpio5" };
 
 static const struct lpi_pingroup sm7150_groups[] = {
 	LPI_PINGROUP(0, 0, slimbus_clk, swr_tx_clk, _, _),
-	LPI_PINGROUP(1, 2, swr_tx_data, audio_ref, _, _),
+	/*
+	 * The SoundWire TX data line on this pin answers to the third mux
+	 * value, not the first: the vendor tree programs func3 here while it
+	 * uses func2 for the same signal on the neighbouring pin. Selecting the
+	 * first slot leaves the line off the bus, and the controller reports a
+	 * bus clash while the TX side of the codec never enumerates.
+	 */
+	LPI_PINGROUP(1, 2, _, audio_ref, swr_tx_data, _),
 	LPI_PINGROUP(2, 4, slimbus_data, swr_tx_data, _, _),
 	LPI_PINGROUP(3, 8, slimbus_data, swr_rx_clk, _, _),
 	LPI_PINGROUP(4, 10, slimbus_data, swr_rx_data, prim_mclk_a, _),


### PR DESCRIPTION
Brings WCD9375 capture on Xiaomi Mi 9T (davinci) to a working state.

This continues #52 by @stsdc, rebased onto `v7.2` and fixed up until the
microphone actually records. His commit is kept as-is, with authorship intact;
everything else is on top.

## What was missing

Four separate problems, three of which turned out to be the same mistake.

| Fix | Effect without it |
|---|---|
| `pinctrl`: `swr_tx_data` on LPI GPIO1 needs mux value 3, not 1 | data line never reaches the bus, `SWR bus clsh detected` on every boot, TX device stays `UNATTACHED` |
| `swr2`: add the wakeup interrupt (`GIC_SPI 500`) | TX device never leaves runtime suspend, sixteen `IRQ sync failed to resume`, ADSP audio service restarts and the card fails with `-EBUSY` — taking the speaker down too |
| `qcom,tx-port-mapping` `<2 3 4 5>` → `<2 2 3 4>`, 10 → 12 channels | ADCs land on the wrong ports, transport never programmed, capture reads silence |
| capture link uses `<&swr2 1>`, not `<&swr2 0>` | `sdw_stream_add_master()` never called, master `DPn_PORT_CTRL` stays zero, controller raises `RD_FIFO_UNDERFLOW` |

One more thing found on the way: the RX and VA macro nodes carried no `status`
property, so they were enabled on *every* sm7150 board - including ones with no
audio codec described at all, such as `sm7150-google-sunfish`. They are now
disabled by default like the TX macro and both controllers next to them, and
davinci turns them on as it already did.

Plus the parts #52 did not have yet: the codec node itself, the capture and VA
dai-links, `audio-routing`, and a `MultiMedia2` frontend.

### The common thread

The TX SoundWire controller on sm7150 has `qcom,dout-ports = <1>`, while the
reference board everything was copied from — `qcm6490-idp` — has none. That
single difference shifts **two** numbering schemes by one:

* master **ports**: the microphone inputs start at port 2, not port 1 (which is
  also why the `qcom,ports-*` arrays of `swr2` begin with `0xff`);
* controller **DAIs**: `qcom_swrm_register_dais()` makes the first
  `num_dout_ports` DAIs playback-only, so DAI 0 here is playback and is never
  given `hw_params` in a capture link.

`qcm6490-idp` can legitimately use `<1 1 2 3>` and `<&swr1 0>`; this board
cannot.

### Why capture needs its own frontend

With only `MultiMedia1`, playback and capture share one PCM, and capture cannot
set hw params while playback is running:

```
$ aplay -D hw:0,0 tone.wav &
$ arecord -D hw:0,0 -f S16_LE -r 48000 -c 1 -d 1 /dev/null
arecord: set_params:1462: Unable to install hw params:
```

So userspace can never hold a source and a sink at the same time — PulseAudio
gives up on the card entirely and falls back to `auto_null`. Adding
`MultiMedia2` for capture follows what other boards do (RB5 plays on
`MultiMedia2`, captures on `MultiMedia3`).

## Scope

Everything here is inert for the other sm7150 boards:

* `sm7150.dtsi` - all the added nodes are `status = "disabled"`, and the wakeup
  interrupt is on a disabled controller. Verified by building
  `sm7150-google-sunfish.dtb`: every macro and both SoundWire controllers come
  out disabled. Only `sm7150-xiaomi-davinci.dtsi` enables them.
* `pinctrl-sm7150-lpass-lpi.c` - `swr_tx_data` only moves from mux slot 1 to
  slot 3 on GPIO1; nothing is removed, GPIO2 and GPIO5 are untouched. The
  function is requested through `tx_swr_active`, referenced solely by the TX
  macro, which is disabled unless a board enables it. The other boards touch
  `&lpass_tlmm` only for `gpio-line-names` and `gpio-reserved-ranges`.
* `sm7150-xiaomi-davinci.dtsi` - this board only.

Tested on the Samsung panel variant; the Visionox one shares the same dtsi and
differs only in the display.

## Testing

Xiaomi Mi 9T (SM7150-AA, Samsung panel), postmarketOS, kernel `v7.2`.

Both SoundWire buses attach with no clashes, the card comes up on every boot,
and the built-in microphone records:

```
noise floor            -62 dBFS
signal to noise ratio   62 dB   (1 kHz acoustic tone)
frequency accuracy      200/400/800/1600/3200/6400 Hz reproduced within
                        measurement error - no sample rate drift
linearity               x1.99, x1.95, x1.94 for successive input doublings
```

Speech recordings are clean. Speaker playback is unaffected.

The microphone sits on `AMIC1` -> codec `ADC1` -> master port 2, which matches
the vendor routing (`"TX SWR_ADC0", "ADC1_OUTPUT"`).

## Userspace note

`ADC2` and `ADC3` must be left off: they share master port 2 with `ADC1`, and
enabling them halves the signal and mixes the neighbouring channel into the
capture stream (noise floor goes from -62 to -20 dBFS). A UCM profile for this
board should disable them explicitly — that part belongs to `alsa-ucm-conf`, not
here.

## Not included

The earpiece is still missing, and the card does not survive an ADSP restart —
`wcd937x_soc_codec_probe()` fails with `-EBUSY` on the second probe. Both are
existing issues, unrelated to this series.
